### PR TITLE
Remove `backoff_ms` arg from connect method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "prime_iroh"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prime_iroh"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "prime_iroh"
-version = "0.2.0"
+version = "0.2.1"
 authors = [{ name = "Mika Senghaas", email = "mika@primeintellect.ai" }]
 description = "Asynchronous P2P communication backend for decentralized pipeline parallelism, built on top of Iroh"
 readme = "README.md"

--- a/python/examples/bidirectional.py
+++ b/python/examples/bidirectional.py
@@ -48,7 +48,7 @@ def main():
     
     # Wait until connection is established
     print("Waiting for connection...")
-    node.connect(peer_id, 10, 100)
+    node.connect(peer_id, 10)
     while not node.is_ready():
         time.sleep(0.1)
     print("Connected to peer!")

--- a/python/examples/unidirectional.py
+++ b/python/examples/unidirectional.py
@@ -52,7 +52,7 @@ def main():
         # Connect to receiver
         print("Connecting to receiver...")
         receiver_id = "9bdb607f02802cdd126290cfa1e025e4c13bbdbb347a70edeace584159303454"
-        node.connect(receiver_id, 10, 100)
+        node.connect(receiver_id, 10)
         
         # Wait for connection to be established
         print("Waiting for sender to be ready...")

--- a/python/prime_iroh/_prime_iroh.pyi
+++ b/python/prime_iroh/_prime_iroh.pyi
@@ -65,13 +65,12 @@ class Node:
         """
         ...
     
-    def connect(self, peer_id_str: str, num_retries: int, backoff_ms: int) -> None:
+    def connect(self, peer_id_str: str, num_retries: int) -> None:
         """Connect to a Node with a given node ID.
         
         Args:
             peer_id_str: The ID of the peer to connect to
             num_retries: The number of retries to attempt
-            backoff_ms: The backoff time in milliseconds
             
         Raises:
             RuntimeError: If connection fails

--- a/python/tests/test_bidirectional.py
+++ b/python/tests/test_bidirectional.py
@@ -10,12 +10,12 @@ class BidirectionalTest:
         self.node0 = Node.with_seed(NUM_STREAMS, None)
         self.node1 = Node.with_seed(NUM_STREAMS, None)
         
-        # Wait for nodes to be ready
+        # Wait for nodes to initialize (only necessary in single process tests)
         time.sleep(1)
 
         # Connect bidirectionally
-        self.node0.connect(self.node1.node_id(), 10, 1000)
-        self.node1.connect(self.node0.node_id(), 10, 1000)
+        self.node0.connect(self.node1.node_id(), 10)
+        self.node1.connect(self.node0.node_id(), 10)
         
         # Wait for connection to be established
         while not self.node0.can_recv() or not self.node1.can_send():

--- a/python/tests/test_connection.py
+++ b/python/tests/test_connection.py
@@ -13,6 +13,9 @@ class ConnectionTest:
             node_id = node.node_id()
             print(f"Initializing node {i} (ID: {node_id})")
             self.nodes.append(node)
+
+        # Wait for nodes to initialize (only necessary in single process tests)
+        time.sleep(1)
         
         # Connect nodes
         for i in range(num_nodes):
@@ -21,7 +24,7 @@ class ConnectionTest:
             node_id = current_node.node_id()
             peer_id = self.nodes[j].node_id()
             print(f"Connecting node {i}->{j} (ID: {node_id}->{peer_id})")
-            current_node.connect(peer_id, 10, 100)
+            current_node.connect(peer_id, 10)
         
         # Wait for all nodes to be ready
         while not all(node.is_ready() for node in self.nodes):

--- a/python/tests/test_unidirectional.py
+++ b/python/tests/test_unidirectional.py
@@ -10,12 +10,12 @@ class UnidirectionalTest:
         # Initialize receiver
         self.receiver = Node(num_streams=NUM_STREAMS)
         
-        # Wait for receiver to be ready
+        # Wait for nodes to initialize (only necessary in single process tests)
         time.sleep(1)
         
         # Initialize sender
         self.sender = Node(num_streams=NUM_STREAMS)
-        self.sender.connect(self.receiver.node_id(), 10, 1000)
+        self.sender.connect(self.receiver.node_id(), 10)
         
         # Wait for connection to be established
         while not self.receiver.can_recv() or not self.sender.can_send():

--- a/rust/examples/bidirectional.rs
+++ b/rust/examples/bidirectional.rs
@@ -59,7 +59,7 @@ fn main() -> Result<()> {
 
     // Wait until connection is established
     println!("Waiting for connection...");
-    node.connect(peer_id, 10, 100)?;
+    node.connect(peer_id, 10)?;
     while !node.is_ready() {
         std::thread::sleep(std::time::Duration::from_millis(100));
     }

--- a/rust/examples/unidirectional.rs
+++ b/rust/examples/unidirectional.rs
@@ -58,7 +58,7 @@ fn main() -> Result<()> {
             println!("Connecting to receiver...");
             let receiver_id =
                 String::from("9bdb607f02802cdd126290cfa1e025e4c13bbdbb347a70edeace584159303454");
-            node.connect(receiver_id, 10, 100)?;
+            node.connect(receiver_id, 10)?;
 
             // Wait for connection to be established
             println!("Waiting for sender to be ready...");

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -118,14 +118,9 @@ impl Node {
         self.inner.node_id().to_string()
     }
 
-    pub fn connect(
-        &mut self,
-        peer_id_str: String,
-        num_retries: usize,
-        backoff_ms: usize,
-    ) -> PyResult<()> {
+    pub fn connect(&mut self, peer_id_str: String, num_retries: usize) -> PyResult<()> {
         self.inner
-            .connect(peer_id_str, num_retries, backoff_ms)
+            .connect(peer_id_str, num_retries)
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 

--- a/rust/src/node.rs
+++ b/rust/src/node.rs
@@ -49,14 +49,9 @@ impl Node {
         self.endpoint.node_id().to_string()
     }
 
-    pub fn connect(
-        &mut self,
-        peer_id_str: String,
-        num_retries: usize,
-        backoff_ms: usize,
-    ) -> Result<()> {
+    pub fn connect(&mut self, peer_id_str: String, num_retries: usize) -> Result<()> {
         self.sender
-            .connect(peer_id_str, self.num_streams, num_retries, backoff_ms)?;
+            .connect(peer_id_str, self.num_streams, num_retries)?;
         Ok(())
     }
 

--- a/rust/src/sender.rs
+++ b/rust/src/sender.rs
@@ -101,7 +101,7 @@ impl Sender {
                     let msg = format!(
                         "Failed to connect {}->{} after {} tries (left: {}): {}",
                         self.endpoint.node_id().fmt_short(),
-                        peer_id_str,
+                        peer_addr.node_id.fmt_short(),
                         num_retries - retries_left,
                         retries_left,
                         e

--- a/rust/src/sender.rs
+++ b/rust/src/sender.rs
@@ -50,7 +50,6 @@ impl Sender {
         peer_id_str: String,
         num_streams: usize,
         num_retries: usize,
-        backoff_ms: usize,
     ) -> Result<()> {
         // Ensure we don't already have a connection
         ensure!(self.connection.is_none(), "Already have a connection");
@@ -66,7 +65,6 @@ impl Sender {
 
         // Connection loop
         let mut retries_left = num_retries;
-        let mut backoff = tokio::time::Duration::from_millis(backoff_ms as u64);
         while retries_left > 0 {
             match self.runtime.block_on(async {
                 // Try to establish connection
@@ -99,27 +97,19 @@ impl Sender {
                     return Ok(());
                 }
                 Err(e) => {
+                    retries_left -= 1;
                     let msg = format!(
-                        "Failed to connect {}->{} after {} retries: {}",
+                        "Failed to connect {}->{} after {} tries (left: {}): {}",
                         self.endpoint.node_id().fmt_short(),
                         peer_id_str,
-                        num_retries,
+                        num_retries - retries_left,
+                        retries_left,
                         e
                     );
                     log::warn!("{}", msg);
-                    retries_left -= 1;
                     if retries_left == 0 {
                         return Err(anyhow!(msg));
                     }
-
-                    // Wait with exponential backoff before retrying
-                    log::warn!("Waiting for {}ms before retrying", backoff.as_millis());
-                    self.runtime.block_on(async {
-                        tokio::time::sleep(backoff).await;
-                    });
-
-                    // Exponential backoff
-                    backoff *= 2;
                 }
             }
         }

--- a/rust/tests/bidirectional.rs
+++ b/rust/tests/bidirectional.rs
@@ -23,13 +23,13 @@ impl BidirectionalTest {
             node0.node_id(),
             node1.node_id()
         );
-        node0.connect(node1.node_id(), 10, 1000)?;
+        node0.connect(node1.node_id(), 10)?;
         println!(
             "Connecting node 1->0 (ID: {}->{})",
             node1.node_id(),
             node0.node_id()
         );
-        node1.connect(node0.node_id(), 10, 1000)?;
+        node1.connect(node0.node_id(), 10)?;
 
         while !node0.can_recv() || !node1.can_send() {
             std::thread::sleep(std::time::Duration::from_millis(100));

--- a/rust/tests/bidirectional.rs
+++ b/rust/tests/bidirectional.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use prime_iroh::node::Node;
+use std::time::Duration;
 
 const NUM_MESSAGES: usize = 5;
 const NUM_STREAMS: usize = 1;
@@ -16,6 +17,9 @@ impl BidirectionalTest {
         println!("Initializing node 0 (ID: {})", node0.node_id());
         let mut node1 = Node::with_seed(NUM_STREAMS, None)?;
         println!("Initializing node 1 (ID: {})", node1.node_id());
+
+        // Wait for nodes to initialize (only necessary in single process tests)
+        std::thread::sleep(Duration::from_millis(1000));
 
         // Connect bidirectionally
         println!(

--- a/rust/tests/connection.rs
+++ b/rust/tests/connection.rs
@@ -22,6 +22,9 @@ impl ConnectionTest {
             node_ids.push(node_id);
         }
 
+        // Wait for nodes to initialize (only necessary in single process tests)
+        std::thread::sleep(Duration::from_millis(1000));
+
         // Connect nodes
         for i in 0..num_nodes {
             let current_node = &mut nodes[i];

--- a/rust/tests/connection.rs
+++ b/rust/tests/connection.rs
@@ -32,7 +32,7 @@ impl ConnectionTest {
                 "Connecting node {}->{} (ID: {}->{})",
                 i, j, node_id, peer_id
             );
-            current_node.connect(peer_id, 10, 100)?;
+            current_node.connect(peer_id, 10)?;
         }
 
         while !nodes.iter().all(|node| node.is_ready()) {

--- a/rust/tests/unidirectional.rs
+++ b/rust/tests/unidirectional.rs
@@ -26,7 +26,7 @@ impl UnidirectionalTest {
             sender.node_id(),
             receiver.node_id()
         );
-        sender.connect(receiver.node_id(), 10, 100)?;
+        sender.connect(receiver.node_id(), 10)?;
 
         // Wait for connection to be established
         while !receiver.can_recv() || !sender.can_send() {

--- a/rust/tests/unidirectional.rs
+++ b/rust/tests/unidirectional.rs
@@ -20,6 +20,9 @@ impl UnidirectionalTest {
         let mut sender = Node::new(NUM_STREAMS)?;
         println!("Initialized sender (ID: {})", sender.node_id());
 
+        // Wait for nodes to initialize (only necessary in single process tests)
+        std::thread::sleep(Duration::from_millis(1000));
+
         // Connect sender to receiver
         println!(
             "Connecting sender->receiver (ID: {}->{})",

--- a/uv.lock
+++ b/uv.lock
@@ -142,7 +142,7 @@ wheels = [
 
 [[package]]
 name = "prime-iroh"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Realized we don't need this, just `num_retries` which triggers every 30s from internal iroh is good as it. Adjusted examples (run without artificial delay), but added back artificial delay when running on the same process (not intended behavior, but convenient for tests)