### PR TITLE
[PRI2-573] Prevent external connection disrupting existing connections

### DIFF
--- a/python/examples/connection.py
+++ b/python/examples/connection.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+This example demonstrates bidirectional communication between two nodes.
+For simplicity, we initialize with known seeds, so that the nodes can
+automatically connect to each other with known connection strings.
+
+Run the receiver:
+    python bidirectional.py rank0
+
+Run the sender:
+    python bidirectional.py rank1
+"""
+
+import sys
+import time
+import logging
+from prime_iroh import Node
+
+def main():
+    # Initialize logging
+    logging.basicConfig(level=logging.INFO)
+    
+    # Get command line arguments
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} [rank0|rank1]")
+        sys.exit(1)
+        
+    num_streams = 1
+    num_messages = 5
+    mode = sys.argv[1]
+    
+    if mode == "rank0":
+        # Initialize variables for rank 0 (define rank 1's connection string)
+        print("Running rank 0")
+        rank = 0
+        peer_id = "ff87a0b0a3c7c0ce827e9cada5ff79e75a44a0633bfcb5b50f99307ddb26b337"
+    elif mode == "rank1":
+        # Initialize variables for rank 1 (define rank 0's connection string)
+        print("Running rank 1")
+        rank = 1
+        peer_id = "ee1aa49a4459dfe813a3cf6eb882041230c7b2558469de81f87c9bf23bf10a03"
+    else:
+        print("Invalid mode. Use 'rank0' or 'rank1'")
+        sys.exit(1)
+        
+    # Initialize node with rank seed
+    node = Node.with_seed(num_streams, seed=rank)
+    
+    # Wait until connection is established
+    print("Waiting for connection...")
+    node.connect(peer_id, 10)
+    while not node.is_ready():
+        time.sleep(0.1)
+    print("Connected to peer!")
+    
+    # Send and receive messages
+    print("Press Ctrl+C to exit...")
+    while True:
+        try:
+            send_msg = f"Hello from rank {rank}"
+            bytes_data = send_msg.encode('utf-8')
+            send_work = node.isend(bytes_data, 0, 1000)
+            
+            # Receive message
+            recv_work = node.irecv(0)
+            bytes_data = recv_work.wait()
+            recv_msg = bytes_data.decode('utf-8')
+            print(f"Received: {recv_msg}")
+            
+            # Wait for send work to complete
+            send_work.wait()
+        except KeyboardInterrupt:
+            print("Keyboard interrupt received, exiting...")
+            break
+    
+    # Clean up
+    node.close()
+
+if __name__ == "__main__":
+    main() 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -21,6 +21,19 @@ use std::sync::RwLock;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
+// Helper function to format errors with full chain
+fn format_error_chain(err: &anyhow::Error) -> String {
+    let mut result = format!("Error: {}", err);
+    let mut source = err.source();
+    while let Some(err) = source {
+        result.push_str(&format!("\nCaused by: {}", err));
+        source = err.source();
+    }
+    // Also log the error to Rust logs
+    log::error!("{}", result);
+    result
+}
+
 #[pyclass]
 pub struct SendWork {
     inner: RwLock<Option<Result<IrohSendWork>>>,
@@ -42,12 +55,12 @@ impl SendWork {
         let mut write_guard = self
             .inner
             .write()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            .map_err(|e| PyRuntimeError::new_err(format!("Lock error: {}", e)))?;
         if let Some(inner) = write_guard.take() {
             inner
                 .unwrap()
                 .wait()
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+                .map_err(|e| PyRuntimeError::new_err(format_error_chain(&e)))
         } else {
             Err(PyRuntimeError::new_err(
                 "SendWork has already been consumed",
@@ -77,12 +90,12 @@ impl RecvWork {
         let mut write_guard = self
             .inner
             .write()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            .map_err(|e| PyRuntimeError::new_err(format!("Lock error: {}", e)))?;
         if let Some(inner) = write_guard.take() {
             inner
                 .unwrap()
                 .wait()
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+                .map_err(|e| PyRuntimeError::new_err(format_error_chain(&e)))
         } else {
             Err(PyRuntimeError::new_err(
                 "RecvWork has already been consumed",
@@ -102,7 +115,7 @@ impl Node {
     pub fn new(num_streams: usize) -> PyResult<Self> {
         Ok(Self {
             inner: IrohNode::new(num_streams)
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
+                .map_err(|e| PyRuntimeError::new_err(format_error_chain(&e)))?,
         })
     }
 
@@ -110,7 +123,7 @@ impl Node {
     pub fn with_seed(num_streams: usize, seed: Option<u64>) -> PyResult<Self> {
         Ok(Self {
             inner: IrohNode::with_seed(num_streams, seed)
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
+                .map_err(|e| PyRuntimeError::new_err(format_error_chain(&e)))?,
         })
     }
 
@@ -121,7 +134,7 @@ impl Node {
     pub fn connect(&mut self, peer_id_str: String, num_retries: usize) -> PyResult<()> {
         self.inner
             .connect(peer_id_str, num_retries)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+            .map_err(|e| PyRuntimeError::new_err(format_error_chain(&e)))
     }
 
     pub fn can_recv(&self) -> bool {
@@ -153,7 +166,7 @@ impl Node {
     pub fn close(&mut self) -> PyResult<()> {
         self.inner
             .close()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+            .map_err(|e| PyRuntimeError::new_err(format_error_chain(&e)))
     }
 }
 
@@ -164,7 +177,7 @@ static INIT: Once = Once::new();
 // Expose classes to Python
 #[pymodule]
 fn _prime_iroh(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    // Initialize logging via environment variables
+    // Initialize logging via environment variables with more detailed configuration
     INIT.call_once(|| {
         env_logger::init();
     });


### PR DESCRIPTION
During benchmarking PP in `prime-rl` it seemed that an external user that is trying to connect to a node in an active group can break the pipeline, causing a `Connection lost` runtime error. This PR tries to fix this by not allowing any incoming connections to disrupt a group once formed.

Ticket: PRI2-573