### PR TITLE
[PRI2-585] Enable broader Linux suport from PyPi wheels

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,36 +18,18 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist
+          args: --release --out dist -i python3.9 -i python3.10 -i python3.11 -i python3.12 -i python3.13
           sccache: 'true'
           manylinux: '2014'
           
-      - name: Upload wheels
+      - name: Upload wheels to PyPI
         uses: PyO3/maturin-action@v1
         with:
           command: upload
-          args: --username __token__ --password ${{ secrets.PYPI_TOKEN }} --skip-existing dist/*
-
-  windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        target: [x64, x86]
-    steps:
-      - uses: actions/checkout@v3
-      
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist
-          sccache: 'true'
-          
-      - name: Upload wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          command: upload
-          args: --username __token__ --password ${{ secrets.PYPI_TOKEN }} --skip-existing dist/*
+          args: --skip-existing dist/*
+        env:
+          MATURIN_USERNAME: __token__
+          MATURIN_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 
   macos:
     runs-on: macos-latest
@@ -61,14 +43,17 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist
+          args: --release --out dist -i python3.9 -i python3.10 -i python3.11 -i python3.12 -i python3.13
           sccache: 'true'
           
-      - name: Upload wheels
+      - name: Upload wheels to PyPI
         uses: PyO3/maturin-action@v1
         with:
           command: upload
-          args: --username __token__ --password ${{ secrets.PYPI_TOKEN }} --skip-existing dist/*
+          args: --skip-existing dist/*
+        env:
+          MATURIN_USERNAME: __token__
+          MATURIN_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 
   sdist:
     runs-on: ubuntu-latest
@@ -81,8 +66,11 @@ jobs:
           command: sdist
           args: --out dist
           
-      - name: Upload sdist
+      - name: Upload sdist to PyPI
         uses: PyO3/maturin-action@v1
         with:
           command: upload
-          args: --username __token__ --password ${{ secrets.PYPI_TOKEN }} --skip-existing dist/*
+          args: --skip-existing dist/*
+        env:
+          MATURIN_USERNAME: __token__
+          MATURIN_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,30 +6,83 @@ on:
       - 'v*'
 
 jobs:
-  build-and-upload-wheels:
-    name: Build and upload wheels on ${{ matrix.os }} for ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
+  linux:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-
+        target: [x86_64, i686]
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install Maturin
-        run: |
-          pip install maturin==1.8.3
-
+      
       - name: Build wheels
-        run: |
-          maturin build --release --manylinux -i ${{ matrix.python-version }}
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          sccache: 'true'
+          manylinux: '2014'
+          
+      - name: Upload wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --username __token__ --password ${{ secrets.PYPI_TOKEN }} --skip-existing dist/*
 
-      - name: Upload to PyPI
-        run: |
-          maturin upload --username __token__ --password ${{ secrets.PYPI_TOKEN }} --skip-existing target/wheels/*
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        target: [x64, x86]
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          sccache: 'true'
+          
+      - name: Upload wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --username __token__ --password ${{ secrets.PYPI_TOKEN }} --skip-existing dist/*
+
+  macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          sccache: 'true'
+          
+      - name: Upload wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --username __token__ --password ${{ secrets.PYPI_TOKEN }} --skip-existing dist/*
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+          
+      - name: Upload sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --username __token__ --password ${{ secrets.PYPI_TOKEN }} --skip-existing dist/*

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -24,7 +24,11 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: upload
-          args: --repository-url https://test.pypi.org/legacy/ --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} --skip-existing dist/*
+          args: --skip-existing dist/*
+        env:
+          MATURIN_REPOSITORY_URL: https://test.pypi.org/legacy/
+          MATURIN_USERNAME: __token__
+          MATURIN_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
 
   windows:
     runs-on: windows-latest
@@ -45,7 +49,11 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: upload
-          args: --repository-url https://test.pypi.org/legacy/ --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} --skip-existing dist/*
+          args: --skip-existing dist/*
+        env:
+          MATURIN_REPOSITORY_URL: https://test.pypi.org/legacy/
+          MATURIN_USERNAME: __token__
+          MATURIN_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
 
   macos:
     runs-on: macos-latest
@@ -66,7 +74,11 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: upload
-          args: --repository-url https://test.pypi.org/legacy/ --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} --skip-existing dist/*
+          args: --skip-existing dist/*
+        env:
+          MATURIN_REPOSITORY_URL: https://test.pypi.org/legacy/
+          MATURIN_USERNAME: __token__
+          MATURIN_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
 
   sdist:
     runs-on: ubuntu-latest
@@ -83,4 +95,8 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: upload
-          args: --repository-url https://test.pypi.org/legacy/ --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} --skip-existing dist/*
+          args: --skip-existing dist/*
+        env:
+          MATURIN_REPOSITORY_URL: https://test.pypi.org/legacy/
+          MATURIN_USERNAME: __token__
+          MATURIN_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -4,30 +4,83 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-upload-wheels:
-    name: Build and upload wheels on ${{ matrix.os }} for ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
+  linux:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-
+        target: [x86_64, i686]
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install Maturin
-        run: |
-          pip install maturin==1.8.3
-
+      
       - name: Build wheels
-        run: |
-          maturin build --release --manylinux -i ${{ matrix.python-version }}
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          sccache: 'true'
+          manylinux: '2014'
+          
+      - name: Upload wheels to Test PyPI
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --repository-url https://test.pypi.org/legacy/ --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} --skip-existing dist/*
 
-      - name: Upload to Test PyPI
-        run: |
-          maturin upload --repository-url https://test.pypi.org/legacy/ --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} --skip-existing target/wheels/*
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        target: [x64, x86]
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          sccache: 'true'
+          
+      - name: Upload wheels to Test PyPI
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --repository-url https://test.pypi.org/legacy/ --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} --skip-existing dist/*
+
+  macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          sccache: 'true'
+          
+      - name: Upload wheels to Test PyPI
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --repository-url https://test.pypi.org/legacy/ --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} --skip-existing dist/*
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+          
+      - name: Upload sdist to Test PyPI
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --repository-url https://test.pypi.org/legacy/ --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} --skip-existing dist/*

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -30,31 +30,6 @@ jobs:
           MATURIN_USERNAME: __token__
           MATURIN_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
 
-  windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        target: [x64, x86]
-    steps:
-      - uses: actions/checkout@v3
-      
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist -i python3.9 -i python3.10 -i python3.11 -i python3.12 -i python3.13
-          sccache: 'true'
-          
-      - name: Upload wheels to Test PyPI
-        uses: PyO3/maturin-action@v1
-        with:
-          command: upload
-          args: --skip-existing dist/*
-        env:
-          MATURIN_REPOSITORY_URL: https://test.pypi.org/legacy/
-          MATURIN_USERNAME: __token__
-          MATURIN_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
-
   macos:
     runs-on: macos-latest
     strategy:

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist
+          args: --release --out dist -i python3.9 -i python3.10 -i python3.11 -i python3.12 -i python3.13
           sccache: 'true'
           manylinux: '2014'
           
@@ -42,7 +42,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist
+          args: --release --out dist -i python3.9 -i python3.10 -i python3.11 -i python3.12 -i python3.13
           sccache: 'true'
           
       - name: Upload wheels to Test PyPI
@@ -67,7 +67,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist
+          args: --release --out dist -i python3.9 -i python3.10 -i python3.11 -i python3.12 -i python3.13
           sccache: 'true'
           
       - name: Upload wheels to Test PyPI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prime_iroh"
-version = "0.3.0.dev0"
+version = "0.3.0-dev0"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prime_iroh"
-version = "0.3.0-dev1"
+version = "0.3.0"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prime_iroh"
-version = "0.2.1"
+version = "0.3.0.dev0"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prime_iroh"
-version = "0.3.0-dev0"
+version = "0.3.0-dev1"
 edition = "2024"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "prime_iroh"
-version = "0.3.0-dev0"
+version = "0.3.0-dev1"
 authors = [{ name = "Mika Senghaas", email = "mika@primeintellect.ai" }]
 description = "Asynchronous P2P communication backend for decentralized pipeline parallelism, built on top of Iroh"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "maturin"
 
 [project]
 name = "prime_iroh"
-version = "0.2.1"
+version = "0.3.0.dev0"
 authors = [{ name = "Mika Senghaas", email = "mika@primeintellect.ai" }]
 description = "Asynchronous P2P communication backend for decentralized pipeline parallelism, built on top of Iroh"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "prime_iroh"
-version = "0.3.0-dev1"
+version = "0.3.0"
 authors = [{ name = "Mika Senghaas", email = "mika@primeintellect.ai" }]
 description = "Asynchronous P2P communication backend for decentralized pipeline parallelism, built on top of Iroh"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "prime_iroh"
-version = "0.3.0.dev0"
+version = "0.3.0-dev0"
 authors = [{ name = "Mika Senghaas", email = "mika@primeintellect.ai" }]
 description = "Asynchronous P2P communication backend for decentralized pipeline parallelism, built on top of Iroh"
 readme = "README.md"


### PR DESCRIPTION
Local setup

```txt
❯ python --version && maturin --version
Python 3.11.12
maturin 1.8.3
```

Activate virtual environment using `source .venv/bin/activate`. Then, run the builds.

Build wheels for `manylinux_2_34` (default)

```bash
❯ maturin build --compatibility manylinux_2_34
📦 Including license file "/home/ubuntu/prime-iroh/LICENSE"
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings
🐍 Found CPython 3.12 at /home/ubuntu/prime-iroh/.venv/bin/python
📡 Using build options features from pyproject.toml
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.24s
📦 Built wheel for CPython 3.12 to /home/ubuntu/prime-iroh/target/wheels/prime_iroh-0.2.1-cp312-cp312-manylinux_2_34_x86_64.whl
```

Build wheels for `manylinux_2_31` locally fails

```bash
❯ maturin build --compatibility manylinux_2_31
📦 Including license file "/home/ubuntu/prime-iroh/LICENSE"
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings
🐍 Found CPython 3.12 at /home/ubuntu/prime-iroh/.venv/bin/python
📡 Using build options features from pyproject.toml
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.24s
💥 maturin failed
  Caused by: Error ensuring manylinux_2_31 compliance
  Caused by: Your library is not manylinux_2_31 compliant because of the presence of too-recent versioned symbols: ["libc.so.6 offending symbols: pthread_join@GLIBC_2.34, pthread_setspecific@GLIBC_2.34, pthread_attr_getguardsize@GLIBC_2.34, pthread_key_create@GLIBC_2.34, pthread_create@GLIBC_2.34, dlsym@GLIBC_2.34, pthread_detach@GLIBC_2.34, pthread_attr_setstacksize@GLIBC_2.34, pthread_attr_getstack@GLIBC_2.34, fstat64@GLIBC_2.33, pthread_setname_np@GLIBC_2.34, pthread_key_delete@GLIBC_2.34, stat64@GLIBC_2.33, pthread_getattr_np@GLIBC_2.32"]. Consider building in a manylinux docker container
```

Build wheels in docker for `manylinux_2014` 

```bash
❯ docker run --rm -v $(pwd):/io ghcr.io/pyo3/maturin:latest build --compatibility manylinux2014
📦 Including license file "/io/LICENSE"
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings
🐍 Found CPython 3.9 at /opt/python/cp39-cp39/bin/python3
📡 Using build options features from pyproject.toml
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.27s
📦 Built wheel for CPython 3.9 to /io/target/wheels/prime_iroh-0.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
```

The key is to build for broad support using Docker. In CI, we can use the `PyO3/maturin-action` to build wheels from source. Also, we now include a source distribution so that users not covered by the wheels can install `prime-iroh` from source.